### PR TITLE
Add support for non-string messages.

### DIFF
--- a/src/factories/createLogger.js
+++ b/src/factories/createLogger.js
@@ -34,24 +34,30 @@ const createLogger = (onMessage: OnMessageEventHandlerType, parentContext: Messa
     let context;
     let message;
 
+    context = {
+      ...global.ROARR.prepend,
+      ...parentContext
+    };
+
     if (typeof a === 'string') {
-      context = {
-        ...global.ROARR.prepend,
-        ...parentContext
-      };
       message = sprintf(a, b, c, d, e, f, g, h, i, k);
-    } else {
-      if (typeof b !== 'string') {
-        throw new TypeError('Message must be a string.');
+    } else if (typeof a === 'object') {
+      if (b === undefined) {
+        message = a;
+      } else {
+        context = {
+          ...context,
+          ...a
+        };
+
+        if (typeof b === 'string') {
+          message = sprintf(b, c, d, e, f, g, h, i, k);
+        } else {
+          message = b;
+        }
       }
-
-      context = {
-        ...global.ROARR.prepend,
-        ...parentContext,
-        ...a
-      };
-
-      message = sprintf(b, c, d, e, f, g, h, i, k);
+    } else {
+      message = a;
     }
 
     onMessage({

--- a/src/types.js
+++ b/src/types.js
@@ -1,8 +1,13 @@
 // @flow
 
+// eslint-disable-next-line no-use-before-define
+export type SerializableType = string | number | boolean | null | SerializableArrayType | SerializableObjectType;
+
 export type SerializableObjectType = {
-  +[key: string]: string | number | null | SerializableObjectType
+  +[key: string]: SerializableType
 };
+
+export type SerializableArrayType = SerializableType[];
 
 export type RoarrGlobalStateType = {
   prepend: SerializableObjectType,
@@ -15,7 +20,7 @@ export type MessageContextType = SerializableObjectType;
 
 export type MessageType = {|
   +context: MessageContextType,
-  +message: string,
+  +message: SerializableType,
   +sequence: number,
   +time: number,
   +version: string

--- a/test/roarr/roarr.js
+++ b/test/roarr/roarr.js
@@ -47,6 +47,98 @@ test('creates a simple message', (t) => {
   ]);
 });
 
+test('creates an object message', (t) => {
+  const log = createLoggerWithHistory();
+
+  log({
+    foo: {
+      bar: 'baz'
+    }
+  });
+
+  t.deepEqual(log.messages, [
+    {
+      context: {},
+      message: {
+        foo: {
+          bar: 'baz'
+        }
+      },
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates an array message', (t) => {
+  const log = createLoggerWithHistory();
+
+  log([{
+    foo: 'bar'
+  }]);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {},
+      message: [{
+        foo: 'bar'
+      }],
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates a null message', (t) => {
+  const log = createLoggerWithHistory();
+
+  log(null);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {},
+      message: null,
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates a number message', (t) => {
+  const log = createLoggerWithHistory();
+
+  log(2);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {},
+      message: 2,
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates a boolean message', (t) => {
+  const log = createLoggerWithHistory();
+
+  log(false);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {},
+      message: false,
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
 test('formats message using sprintf', (t) => {
   const log = createLoggerWithHistory();
 
@@ -76,6 +168,114 @@ test('creates message with a context', (t) => {
         foo: 'bar'
       },
       message: 'baz',
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates an object message with a context', (t) => {
+  const log = createLoggerWithHistory();
+
+  log({
+    foo: 'bar'
+  }, {
+    bar: 'foo'
+  });
+
+  t.deepEqual(log.messages, [
+    {
+      context: {
+        foo: 'bar'
+      },
+      message: {
+        bar: 'foo'
+      },
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates an array message with a context', (t) => {
+  const log = createLoggerWithHistory();
+
+  log({
+    foo: 'bar'
+  }, [{
+    bar: 'foo'
+  }]);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {
+        foo: 'bar'
+      },
+      message: [{
+        bar: 'foo'
+      }],
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates a null message with a context', (t) => {
+  const log = createLoggerWithHistory();
+
+  log({
+    foo: 'bar'
+  }, null);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {
+        foo: 'bar'
+      },
+      message: null,
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates a boolean message with a context', (t) => {
+  const log = createLoggerWithHistory();
+
+  log({
+    foo: 'bar'
+  }, false);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {
+        foo: 'bar'
+      },
+      message: false,
+      sequence,
+      time,
+      version
+    }
+  ]);
+});
+
+test('creates a number message with a context', (t) => {
+  const log = createLoggerWithHistory();
+
+  log({
+    foo: 'bar'
+  }, 2);
+
+  t.deepEqual(log.messages, [
+    {
+      context: {
+        foo: 'bar'
+      },
+      message: 2,
       sequence,
       time,
       version


### PR DESCRIPTION
Added support for logging objects, while maintaining the sprintf behavior for strings and passing context as the first argument.

In addition other types are also supported: `null`, `number`, `boolean`, `array`