### PR TITLE
sets minimum version of boolean to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "dependencies": {
-    "boolean": "^2.0.2",
+    "boolean": "^2.0.3",
     "detect-node": "^2.0.4",
     "globalthis": "^1.0.0",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
with 2.0.3 they remove the named capture group from a regexp which isn't supported on node  < 10 and thus would be considered a breaking change to roarr.
That said, with this PR, everything is fine again and also automated tests for my repos (depending on roarr) work on node 8 and node 9 again.