### PR TITLE
fix: ensure pkg.version exists

### DIFF
--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -17,7 +17,7 @@ export default (currentState: any): RoarrGlobalState => {
 
   if (pkg.version && !versions.includes(pkg.version)) {
     versions.push(pkg.version);
-    
+
     if (versions.length > 1) {
       versions.sort(cmp);
     }

--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -13,7 +13,7 @@ export default (currentState: any): RoarrGlobalState => {
     versions.sort(cmp);
   }
 
-  const currentIsLatestVersion = versions.length < 1 || cmp(pkg.version, versions[versions.length - 1]) === 1;
+  const currentIsLatestVersion = versions.length < 2 || cmp(pkg.version, versions[versions.length - 1]) === 1;
 
   if (pkg.version && !versions.includes(pkg.version)) {
     versions.push(pkg.version);

--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -13,7 +13,7 @@ export default (currentState: any): RoarrGlobalState => {
     versions.sort(cmp);
   }
 
-  const currentIsLatestVersion = versions.length < 2 || cmp(pkg.version, versions[versions.length - 1]) === 1;
+  const currentIsLatestVersion = versions.length < 1 || cmp(pkg.version, versions[versions.length - 1]) === 1;
 
   if (pkg.version && !versions.includes(pkg.version)) {
     versions.push(pkg.version);

--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -13,7 +13,7 @@ export default (currentState: any): RoarrGlobalState => {
     versions.sort(cmp);
   }
 
-  const currentIsLatestVersion = versions.length === 1 || cmp(pkg.version, versions[versions.length - 1]) === 1;
+  const currentIsLatestVersion = versions.length < 2 || cmp(pkg.version, versions[versions.length - 1]) === 1;
 
   if (pkg.version && !versions.includes(pkg.version)) {
     versions.push(pkg.version);

--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -13,13 +13,15 @@ export default (currentState: any): RoarrGlobalState => {
     versions.sort(cmp);
   }
 
-  const currentIsLatestVersion = !versions.length || cmp(pkg.version, versions[versions.length - 1]) === 1;
+  const currentIsLatestVersion = versions.length === 1 || cmp(pkg.version, versions[versions.length - 1]) === 1;
 
-  if (!versions.includes(pkg.version)) {
+  if (pkg.version && !versions.includes(pkg.version)) {
     versions.push(pkg.version);
+    
+    if (versions.length > 1) {
+      versions.sort(cmp);
+    }
   }
-
-  versions.sort(cmp);
 
   let newState = {
     sequence: 0,


### PR DESCRIPTION
when the dependency is installed as `cjs`, the `package.json` only contains the `type`:

```
root@03c664885d77:/usr/src/app/node_modules/roarr/dist/cjs# cat package.json
{"type": "commonjs"}
root@03c664885d77:/usr/src/app/node_modules/roarr/dist/cjs#
```

so it's causing a non-expected behavior, adding `undefined` into the collection of versions.


related with #38