### PR TITLE
Upgrading fast-json-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "boolean": "^3.0.2",
     "detect-node": "^2.0.4",
-    "fast-json-stringify": "^2.4.2",
+    "fast-json-stringify": "^2.5.2",
     "fast-printf": "^1.6.2",
     "globalthis": "^1.0.2",
     "is-circular": "^1.0.2",


### PR DESCRIPTION
Current version of `fast-json-stringify` has issues with `long` packages (its dependency) which has been fixed in the latest version.