### PR TITLE
fix: update path to typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "lint": "eslint ./src ./test && tsc --noEmit",
     "test": "NODE_ENV=test ava --serial --verbose"
   },
-  "typings": "./dist/src/log.d.ts",
+  "typings": "./dist/src/Roarr.d.ts",
   "version": "1.0.0"
 }


### PR DESCRIPTION
Due to filename changes in 444b1b13454144573f26b125f65989429be26406, typings property should point to new location to avoid `Could not find a declaration file for module 'roarr'` error.