### PR TITLE
feat: Added `onMessage` property — allows overriding global message handler

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -424,6 +424,18 @@ Produces output:
 
 ```
 
+### `onMessage`
+
+Optionally, replace the global message handler:
+
+```ts
+import { Roarr } from 'roarr';
+
+Roarr.onMessage = (message) => {
+  console.log(JSON.stringify(message, null, 2));
+}
+```
+
 ## Middlewares
 
 Roarr logger supports middlewares implemented as [`child`](#child) message translate functions, e.g.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ JSON logger for Node.js and browser.
         * [`warn`](#roarr-api-warn)
         * [`error`](#roarr-api-error)
         * [`fatal`](#roarr-api-fatal)
+        * [`onMessage`](#roarr-api-onmessage)
     * [Middlewares](#roarr-middlewares)
     * [CLI program](#roarr-cli-program)
     * [Transports](#roarr-transports)
@@ -479,6 +480,19 @@ Produces output:
 {"context":{"logLevel":50},"message":"foo","sequence":"4","time":1506776210000,"version":"2.0.0"}
 {"context":{"logLevel":60},"message":"foo","sequence":"5","time":1506776210000,"version":"2.0.0"}
 
+```
+
+<a name="roarr-api-onmessage"></a>
+### <code>onMessage</code>
+
+Optionally, replace the global message handler:
+
+```ts
+import { Roarr } from 'roarr';
+
+Roarr.onMessage = (message) => {
+  console.log(JSON.stringify(message, null, 2));
+}
 ```
 
 <a name="roarr-middlewares"></a>

--- a/src/factories/createLogger.ts
+++ b/src/factories/createLogger.ts
@@ -126,7 +126,7 @@ const createLogger = (
       );
     }
 
-    onMessage({
+    log.onMessage({
       context,
       message,
       sequence,
@@ -134,6 +134,8 @@ const createLogger = (
       version: ROARR_LOG_FORMAT_VERSION,
     });
   };
+
+  log.onMessage = onMessage;
 
   log.child = (context: MessageContext | TranslateMessageFunction) => {
     if (typeof context === 'function') {
@@ -145,13 +147,13 @@ const createLogger = (
             throw new Error('Child middleware function must return a message object.');
           }
 
-          onMessage(nextMessage);
+          log.onMessage(nextMessage);
         },
         parentContext,
       );
     }
 
-    return createLogger(onMessage, {
+    return createLogger(log.onMessage, {
       ...getAsyncLocalContext(),
       ...parentContext,
       ...context,
@@ -172,7 +174,7 @@ const createLogger = (
       if (loggedWarning === false) {
         loggedWarning = true;
 
-        onMessage({
+        log.onMessage({
           context: {
             logLevel: logLevels.warn,
             package: 'roarr',

--- a/src/factories/createMockLogger.ts
+++ b/src/factories/createMockLogger.ts
@@ -16,6 +16,7 @@ const createMockLogger = (
     return undefined;
   };
 
+  log.onMessage = onMessage;
   log.adopt = async (routine) => {
     return routine();
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type Logger = LogMethod & {
   info: LogMethod,
   trace: LogMethod,
   warn: LogMethod,
+  onMessage: MessageEventHandler,
 };
 
 export type MessageEventHandler = (message: Message) => void;

--- a/test/roarr/roarr.ts
+++ b/test/roarr/roarr.ts
@@ -139,6 +139,33 @@ test('creates message with a context', (t) => {
   ]);
 });
 
+test('can change message handler', (t) => {
+  const log = createLoggerWithHistory();
+
+  let msg: any = undefined;
+  const newHandler = (arg) => msg = { ...arg, time };
+
+  t.assert(typeof log.onMessage === 'function');
+  t.assert(log.onMessage !== newHandler);
+  log.onMessage = newHandler;
+
+  log({
+    foo: 'bar'
+  }, 'msg');
+
+  t.deepEqual(msg, {
+    context: {
+      foo: 'bar',
+    },
+    message: 'msg',
+    sequence: '0',
+    time,
+    version,
+  });
+
+  t.assert(log.messages.length === 0);
+});
+
 test('formats message using sprintf (with context)', (t) => {
   const log = createLoggerWithHistory();
 

--- a/test/roarr/roarr.ts
+++ b/test/roarr/roarr.ts
@@ -142,15 +142,20 @@ test('creates message with a context', (t) => {
 test('can change message handler', (t) => {
   const log = createLoggerWithHistory();
 
-  let msg: any = undefined;
-  const newHandler = (arg) => msg = { ...arg, time };
+  let msg: any;
+  const newHandler = (arg) => {
+    msg = {
+      ...arg,
+      time,
+    };
+  };
 
   t.assert(typeof log.onMessage === 'function');
   t.assert(log.onMessage !== newHandler);
   log.onMessage = newHandler;
 
   log({
-    foo: 'bar'
+    foo: 'bar',
   }, 'msg');
 
   t.deepEqual(msg, {


### PR DESCRIPTION
## Background

It is currently impossible to override message handler functionality with NodeJS and `slonik`. We are not able to use the `cli` application, and we need a way to directly feed the log messages in to be handled by our current core system.

## Solution

This PR adds `onMessage` to the module `Roarr` instance, allowing us to swap it for a custom handler.