### PR TITLE
feat: support message transformer in the context of "adopt" (fixes #60)

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -212,7 +212,7 @@ Refer to the [Usage documentation](#usage) for common usage examples.
 ### `adopt`
 
 ```ts
-<T>(routine: () => Promise<T>, context: MessageContext) => Promise<T>,
+<T>(routine: () => Promise<T>, context: MessageContext | TransformMessageFunction<MessageContext>) => Promise<T>,
 ```
 
 `adopt` function uses Node.js [`async_context`](https://nodejs.org/api/async_context.html) to pass-down context properties.
@@ -323,7 +323,7 @@ barLog.debug('foo 2');
 #### Function parameter
 
 ```ts
-<T>(context: TranslateMessageFunction<MessageContext<T>>): Logger<T>
+<T>(context: TransformMessageFunction<MessageContext<T>>): Logger<T>
 ```
 
 Creates a child logger that translates every subsequent message.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Refer to the [Usage documentation](#usage) for common usage examples.
 ### <code>adopt</code>
 
 ```ts
-<T>(routine: () => Promise<T>, context: MessageContext) => Promise<T>,
+<T>(routine: () => Promise<T>, context: MessageContext | TransformMessageFunction<MessageContext>) => Promise<T>,
 ```
 
 `adopt` function uses Node.js [`async_context`](https://nodejs.org/api/async_context.html) to pass-down context properties.
@@ -378,7 +378,7 @@ barLog.debug('foo 2');
 #### Function parameter
 
 ```ts
-<T>(context: TranslateMessageFunction<MessageContext<T>>): Logger<T>
+<T>(context: TransformMessageFunction<MessageContext<T>>): Logger<T>
 ```
 
 Creates a child logger that translates every subsequent message.

--- a/src/Roarr.ts
+++ b/src/Roarr.ts
@@ -69,7 +69,7 @@ export type {
   Message,
   MessageEventHandler,
   RoarrGlobalState,
-  TranslateMessageFunction,
+  TransformMessageFunction,
 } from './types';
 
 export {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -35,7 +35,7 @@ export type {
   Message,
   MessageEventHandler,
   RoarrGlobalState,
-  TranslateMessageFunction,
+  TransformMessageFunction,
 } from './types';
 
 export {

--- a/src/utilities/hasOwnProperty.ts
+++ b/src/utilities/hasOwnProperty.ts
@@ -1,0 +1,11 @@
+/**
+ * A stricter type guard.
+ *
+ * @see https://tsplay.dev/WK8zGw
+ */
+export const hasOwnProperty = <X extends {}, Y extends PropertyKey>(
+  object: X,
+  property: Y,
+): object is Record<Y, unknown> & X => {
+  return Object.prototype.hasOwnProperty.call(object, property);
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,3 @@
+export {
+  hasOwnProperty,
+} from './hasOwnProperty';

--- a/test/roarr/roarr.ts
+++ b/test/roarr/roarr.ts
@@ -70,6 +70,17 @@ test('logs an empty message when first parameter is an object and the second par
   ]);
 });
 
+test('throws in case of invalid invocation', (t) => {
+  const log = createLoggerWithHistory();
+
+  t.throws(() => {
+    // @ts-expect-error Invalid invocation
+    log({}, {});
+  }, {
+    message: 'Message must be a string. Received object.',
+  });
+});
+
 test('formats message using sprintf', (t) => {
   const log = createLoggerWithHistory();
 
@@ -370,7 +381,7 @@ test('throws an error if child does not return an object', (t) => {
         return '';
       })('foo');
   }, {
-    message: 'Child middleware function must return a message object.',
+    message: 'Message transform function must return a message object.',
   });
 });
 


### PR DESCRIPTION
Before:

```
simple message x 1,456,083 ops/sec ±0.99% (95 runs sampled)
message with printf x 1,092,793 ops/sec ±0.95% (96 runs sampled)
message with context x 1,307,103 ops/sec ±0.98% (95 runs sampled)
message with large context x 1,399,549 ops/sec ±1.72% (75 runs sampled)
message with large context x 1,387,441 ops/sec ±1.92% (75 runs sampled)
```

After:

```
simple message x 1,309,177 ops/sec ±0.67% (97 runs sampled)
message with printf x 969,862 ops/sec ±0.94% (97 runs sampled)
message with context x 1,112,226 ops/sec ±1.04% (98 runs sampled)
message with large context x 1,231,458 ops/sec ±1.75% (76 runs sampled)
message with large context x 1,245,710 ops/sec ±1.59% (76 runs sampled)
```

Insignificant performance degradation.