### PR TITLE
[#79] fix: avoid persistent stream error listeners

### DIFF
--- a/src/factories/createNodeWriter.ts
+++ b/src/factories/createNodeWriter.ts
@@ -2,7 +2,17 @@ import { type LogWriter } from '../types';
 
 const createBlockingWriter = (stream: NodeJS.WritableStream): LogWriter => {
   return (message: string) => {
-    stream.write(message + '\n');
+    stream.write(message + '\n', (error?: Error | null) => {
+      if (!error) {
+        return;
+      }
+
+      if ('code' in error && error.code === 'EPIPE') {
+        return;
+      }
+
+      throw error;
+    });
   };
 };
 
@@ -10,16 +20,7 @@ export const createNodeWriter = (): LogWriter => {
   // eslint-disable-next-line node/no-process-env
   const targetStream = (process.env.ROARR_STREAM ?? 'STDOUT').toUpperCase();
 
-  const stream =
-    targetStream.toUpperCase() === 'STDOUT' ? process.stdout : process.stderr;
-
-  stream.on('error', (error) => {
-    if (error.code === 'EPIPE') {
-      return;
-    }
-
-    throw error;
-  });
+  const stream = targetStream === 'STDOUT' ? process.stdout : process.stderr;
 
   return createBlockingWriter(stream);
 };


### PR DESCRIPTION
Pass callback for write instead of registering global one