### PR TITLE
[#79] feat: introduce cleanup API to clear registered global stdout/stderr listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,22 @@ const serializeMessage: MessageSerializer = (message) => {
 ROARR.serializeMessage = serializeMessage;
 ```
 
+### Cleaning up Roarr in test environments
+
+In Node.js, Roarr registers an `error` listener on the configured output stream to ignore `EPIPE` errors. Test runners that create isolated module environments may need to remove that listener during teardown.
+
+```ts
+import {
+  ROARR,
+} from 'roarr';
+
+afterEach(() => {
+  ROARR.teardown?.();
+});
+```
+
+This is only needed for test environments that repeatedly load Roarr in the same process.
+
 ### Logging errors
 
 This is not specific to Roarr – this suggestion applies to any kind of logging.

--- a/src/factories/createNodeWriter.ts
+++ b/src/factories/createNodeWriter.ts
@@ -1,25 +1,41 @@
 import { type LogWriter } from '../types';
 
+export type NodeWriter = {
+  teardown: () => void;
+  write: LogWriter;
+};
+
 const createBlockingWriter = (stream: NodeJS.WritableStream): LogWriter => {
   return (message: string) => {
     stream.write(message + '\n');
   };
 };
 
-export const createNodeWriter = (): LogWriter => {
+const createOnError = () => {
+  return (error) => {
+    if (error.code === 'EPIPE') {
+      return;
+    }
+
+    throw error;
+  };
+};
+
+export const createNodeWriter = (): NodeWriter => {
   // eslint-disable-next-line node/no-process-env
   const targetStream = (process.env.ROARR_STREAM ?? 'STDOUT').toUpperCase();
 
   const stream =
     targetStream.toUpperCase() === 'STDOUT' ? process.stdout : process.stderr;
 
-  stream.on('error', (error) => {
-    if (error.code === 'EPIPE') {
-      return;
-    }
+  const onError = createOnError();
 
-    throw error;
-  });
+  stream.on('error', onError);
 
-  return createBlockingWriter(stream);
+  return {
+    teardown: () => {
+      stream.removeListener('error', onError);
+    },
+    write: createBlockingWriter(stream),
+  };
 };

--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -31,6 +31,11 @@ export const createRoarrInitialGlobalState = (
 
   if (currentIsLatestVersion || !newState.write) {
     try {
+      newState.teardown?.();
+      // eslint-disable-next-line no-empty
+    } catch {}
+
+    try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
       const AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage;
 

--- a/src/factories/createRoarrInitialGlobalState.ts
+++ b/src/factories/createRoarrInitialGlobalState.ts
@@ -35,12 +35,14 @@ export const createRoarrInitialGlobalState = (
       const AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage;
 
       const asyncLocalStorage = new AsyncLocalStorage();
+      const nodeWriter = createNodeWriter();
 
       newState = {
         ...newState,
 
         asyncLocalStorage,
-        write: createNodeWriter(),
+        teardown: nodeWriter.teardown,
+        write: nodeWriter.write,
       };
       // eslint-disable-next-line no-empty
     } catch {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export type RoarrGlobalState = {
   onceLog: Set<string>;
   sequence: number;
   serializeMessage?: MessageSerializer;
+  teardown?: () => void;
   versions: readonly string[];
   write: LogWriter;
 };

--- a/test/helpers/createIntegrationTest.ts
+++ b/test/helpers/createIntegrationTest.ts
@@ -35,5 +35,9 @@ export const createIntegrationTest = ({
     };
   });
 
+  test.afterEach((t) => {
+    t.context.ROARR.teardown?.();
+  });
+
   return test;
 };

--- a/test/roarr/createRoarrInitialGlobalState.ts
+++ b/test/roarr/createRoarrInitialGlobalState.ts
@@ -5,6 +5,10 @@ import test from 'ava';
 test('creates new state', (t) => {
   const state = createRoarrInitialGlobalState({});
 
+  t.teardown(() => {
+    state.teardown?.();
+  });
+
   t.like(state, {
     sequence: 0,
     versions: [ROARR_VERSION],
@@ -14,6 +18,10 @@ test('creates new state', (t) => {
 test('respects existing sequence', (t) => {
   const state = createRoarrInitialGlobalState({
     sequence: 1,
+  });
+
+  t.teardown(() => {
+    state.teardown?.();
   });
 
   t.like(state, {
@@ -27,6 +35,10 @@ test('appends the latest version', (t) => {
     versions: ['0.0.1'],
   });
 
+  t.teardown(() => {
+    state.teardown?.();
+  });
+
   t.like(state, {
     sequence: 0,
     versions: ['0.0.1', ROARR_VERSION],
@@ -36,6 +48,10 @@ test('appends the latest version', (t) => {
 test('sets "write" method if current is the first version', (t) => {
   const state = createRoarrInitialGlobalState({});
 
+  t.teardown(() => {
+    state.teardown?.();
+  });
+
   t.is(typeof state.write, 'function');
 });
 
@@ -43,6 +59,10 @@ test('overrides "write" method if current is the latest version', (t) => {
   const state = createRoarrInitialGlobalState({
     versions: ['0.0.1'],
     write: 'foo',
+  });
+
+  t.teardown(() => {
+    state.teardown?.();
   });
 
   t.is(typeof state.write, 'function');

--- a/test/roarr/integrations/asyncLocalScope.ts
+++ b/test/roarr/integrations/asyncLocalScope.ts
@@ -15,9 +15,14 @@ const time = -1;
 const version = '2.0.0';
 
 test.beforeEach(() => {
+  globalThis.ROARR?.teardown?.();
   globalThis.ROARR = null;
 
   globalThis.ROARR = createRoarrInitialGlobalState({});
+});
+
+test.afterEach(() => {
+  globalThis.ROARR?.teardown?.();
 });
 
 const createLoggerWithHistory = (): Logger & { messages: Message[] } => {

--- a/test/roarr/integrations/roarr.ts
+++ b/test/roarr/integrations/roarr.ts
@@ -11,7 +11,12 @@ const time = -1;
 const version = '2.0.0';
 
 test.beforeEach(() => {
+  globalThis.ROARR?.teardown?.();
   globalThis.ROARR = createRoarrInitialGlobalState({});
+});
+
+test.afterEach(() => {
+  globalThis.ROARR?.teardown?.();
 });
 
 const createLoggerWithHistory = (): Logger & { messages: Message[] } => {


### PR DESCRIPTION
Adds a teardown hook for Roarr’s Node stream error listener so test environments can remove it between isolated module runs.

The new `ROARR.teardown?.()` API removes the listener that Roarr registered, which lets test runners avoid accumulating listeners on shared `process.stdout` / `process.stderr` streams.

Fixes #79.

Here's an alternative approach that seems cleaner but may make performance slightly worse than it is now: https://github.com/gajus/roarr/pull/91.