### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "name": "roarr",
   "repository": {
     "type": "git",
-    "url": "git@github.com:gajus/roarr.git"
+    "url": "git+https://github.com/gajus/roarr.git"
   },
   "scripts": {
     "benchmark": "ROARR_LOG=true tsx test/benchmark.ts",


### PR DESCRIPTION
## Summary
- replace the SSH repository URL with a public HTTPS URL
- let npm tooling and consumers resolve the source repository without GitHub SSH credentials

## Validation
- TypeScript build (`tsc --project tsconfig.build.json`)
- TypeScript type check (`tsc`)
- Knip (exit 0)
- AVA: 51 tests passed
- `pnpm pack --dry-run --json`
- package metadata assertion and `git diff --check`